### PR TITLE
补充 \expandafter。

### DIFF
--- a/edocstrip/edocstrip.tex
+++ b/edocstrip/edocstrip.tex
@@ -1,5 +1,5 @@
 \expandafter\ifx\csname edocstripversion\endcsname\relax\else
-  \endinput
+  \expandafter\endinput
 \fi
 
 \chardef\edocstripversion=1


### PR DESCRIPTION
应该在 \endinput 前展开 \fi 或者将它们放在同一行，否则重复载入时会出现 \ifx 不完整。
